### PR TITLE
ECO-873: Fixes failing test with Bytes wrapper

### DIFF
--- a/tests/src/kv_storage.rs
+++ b/tests/src/kv_storage.rs
@@ -1,8 +1,7 @@
 use casper_engine_test_support::{Code, Hash, SessionBuilder, TestContext, TestContextBuilder};
 use casper_types::{
     account::AccountHash,
-    bytesrepr::FromBytes,
-    bytesrepr::Bytes,
+    bytesrepr::{Bytes, FromBytes},
     runtime_args,
     CLTyped,
     RuntimeArgs,

--- a/tests/src/kv_storage.rs
+++ b/tests/src/kv_storage.rs
@@ -2,6 +2,7 @@ use casper_engine_test_support::{Code, Hash, SessionBuilder, TestContext, TestCo
 use casper_types::{
     account::AccountHash,
     bytesrepr::FromBytes,
+    bytesrepr::Bytes,
     runtime_args,
     CLTyped,
     RuntimeArgs,
@@ -87,7 +88,7 @@ impl KVstorageContract {
         self.context.run(session);
     }
 
-    pub fn call_store_bytes(&mut self, name: String, value: Vec<u8>) {
+    pub fn call_store_bytes(&mut self, name: String, value: Bytes) {
         let code = Code::Hash(self.kvstorage_hash, "store_bytes".to_string());
         let args = runtime_args! {
             "name" => name,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,7 +4,7 @@ mod kv_storage;
 #[cfg(test)]
 mod tests {
     use super::kv_storage;
-    use casper_types::{account::AccountHash, U512};
+    use casper_types::{account::AccountHash, U512, bytesrepr::Bytes};
     use kv_storage::KVstorageContract;
 
     #[test]
@@ -34,10 +34,10 @@ mod tests {
         const KEY_NAME: &str = "test_bytes";
         let mut kv_storage = KVstorageContract::deploy();
         let name: String = String::from("test_bytes");
-        let value: Vec<u8> = vec![0x41u8, 0x41u8, 0x42u8];
+        let value: Bytes = vec![0x41u8, 0x41u8, 0x42u8].into();
         let value2 = value.clone();
         kv_storage.call_store_bytes(name, value);
-        let check: Vec<u8> = kv_storage.query_contract(&KEY_NAME).unwrap();
+        let check: Bytes = kv_storage.query_contract(&KEY_NAME).unwrap();
         assert_eq!(value2, check);
     }
 


### PR DESCRIPTION
Fixes the failing test from the last PR by replacing Vec<u8> with casper_types::bytesrepr::Bytes